### PR TITLE
Address compilation errors under Ubuntu 24.04 / gcc 13 / C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,29 @@
 # Copyright (c) 2020 Emmanuel Arias
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+# Build in release mode by default
+if (NOT CMAKE_BUILD_TYPE)
+    message("MAKE_BUILD_TYPE unset, set CMAKE_BUILD_TYPE=Release")
+    set(CMAKE_BUILD_TYPE Release CACHE INTERNAL "")
+endif()
+
+
+set(CMAKE_C_STANDARD                99)
+# use C++20 so as to allow us to use <format>
+set(CMAKE_CXX_STANDARD              23)
+
+# Make the standard a requirement => prevent fallback to previous
+# supported standard
+set(CMAKE_C_STANDARD_REQUIRED       ON)
+set(CMAKE_CXX_STANDARD_REQUIRED     ON)
+
+# We want to pass standard C/C++ flags, without gnu extensions
+set(CMAKE_C_EXTENSIONS              OFF)
+set(CMAKE_CXX_EXTENSIONS            OFF)
+
+
 project(producer-consumer-example)
 
 file(GLOB_RECURSE SOURCE_FILES 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,5 @@
 # Copyright (c) 2020 Emmanuel Arias
-# SPDX-License-Identifier: MIT
-
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-
-# Build in release mode by default
-if (NOT CMAKE_BUILD_TYPE)
-    message("MAKE_BUILD_TYPE unset, set CMAKE_BUILD_TYPE=Release")
-    set(CMAKE_BUILD_TYPE Release CACHE INTERNAL "")
-endif()
-
-
-set(CMAKE_C_STANDARD                99)
-# use C++20 so as to allow us to use <format>
-set(CMAKE_CXX_STANDARD              23)
-
-# Make the standard a requirement => prevent fallback to previous
-# supported standard
-set(CMAKE_C_STANDARD_REQUIRED       ON)
-set(CMAKE_CXX_STANDARD_REQUIRED     ON)
-
-# We want to pass standard C/C++ flags, without gnu extensions
-set(CMAKE_C_EXTENSIONS              OFF)
-set(CMAKE_CXX_EXTENSIONS            OFF)
-
-
 project(producer-consumer-example)
 
 file(GLOB_RECURSE SOURCE_FILES 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Minimal implementations in Modern C++: Producer-Consumer problem
+
+Emmanuel Arias
+
+See writeup ["Minimal implementations in Modern C++: Producer-Consumer problem"](https://eariassoto.github.io/post/producer-consumer/) in [GitHub Pages](https://pages.github.com).
+
+### Building:
+
+MSVC:
+```
+build.bat
+```
+
+Linux:
+```
+mkdir build && cd build
+cmake ..
+make -j
+```

--- a/src/include/task_queue.h
+++ b/src/include/task_queue.h
@@ -2,9 +2,17 @@
 #pragma once
 #include <mutex>
 #include <queue>
-#include <tuple>
+#include <condition_variable>
 
 class Task;
+
+class TaskQueueSubscription {
+   public:
+    TaskQueueSubscription(std::mutex& mutex, std::condition_variable& conditionvar)
+        : m(mutex), cv(conditionvar) {}
+    std::mutex& m;
+    std::condition_variable& cv;
+};
 
 class TaskQueue {
    public:
@@ -15,7 +23,7 @@ class TaskQueue {
     void PushTasks(std::vector<Task*>& tasks);
     void StopQueue();
     // Way for consumers to get the sync variables
-    std::tuple<std::mutex&, std::condition_variable&> Subscribe();
+    TaskQueueSubscription Subscribe();
 
     // Non-thread safe function. Consumers must ensure
     // lock acquisition

--- a/src/task_queue.cpp
+++ b/src/task_queue.cpp
@@ -14,9 +14,8 @@ TaskQueue::~TaskQueue() {
     }
 }
 
-std::tuple<std::mutex&, std::condition_variable&>
-TaskQueue::Subscribe() {
-    return std::make_tuple(std::ref(m_Mutex), std::ref(m_ConditionVariable));
+TaskQueueSubscription TaskQueue::Subscribe() {
+    return TaskQueueSubscription(std::ref(m_Mutex), std::ref(m_ConditionVariable));
 }
 
 void TaskQueue::PushTask(Task* t) {

--- a/src/worker_thread.cpp
+++ b/src/worker_thread.cpp
@@ -10,12 +10,12 @@
 
 void WorkerThread(const int workerId, TaskQueue& taskQueue,
                   std::mutex& coutMutex) {
-    auto& [m, cv] = taskQueue.Subscribe();
+    const TaskQueueSubscription& taskq = taskQueue.Subscribe();
 
     while (true) {
         auto data = [&]() -> std::optional<Task*> {
-            std::unique_lock l{m};
-            cv.wait(l, [&] {
+            std::unique_lock l{taskq.m};
+            taskq.cv.wait(l, [&] {
                 return taskQueue.IsQueueStopped() || taskQueue.HasPendingTask();
             });
             if (taskQueue.IsQueueStopped()) {


### PR DESCRIPTION
Hi! Nice project. It's easy to follow and (I hope!) avoids the [coding pitfalls described by Adam Nevraumont](https://stackoverflow.com/a/57220255/198374).

I ran into some compilation errors under Ubuntu 24.04 / gcc13. I'm using C++23

* missing `#include`:
```
src/include/task_queue.h:18:34: error: ‘condition_variable’ is not a member of ‘std’
```
* problems with structure binding a tuple. 
```
src/worker_thread.cpp:13:40: error: cannot bind non-const lvalue reference of type
 ‘std::tuple<std::mutex&, std::condition_variable&>&’ to an rvalue of type 
 ‘std::tuple<std::mutex&, std::condition_variable&>’
```

I addressed the second by making returning const class `TaskQueueSubscription` instead of a generic `std::tuple` and structure binding.

The only functional commit is 2f654fa754dcc8b5171ff005c8fdc861e80d6f27.